### PR TITLE
deal with deprecated vcat warnings

### DIFF
--- a/src/rasta.jl
+++ b/src/rasta.jl
@@ -239,7 +239,7 @@ function lifter{T<:AbstractFloat}(x::Array{T}, lift::Real=0.6, invs=false)
         if !isa(lift, Int)
             error("Negative lift must be interger")
         end
-        liftw = [1, (1 + lift/2*sin([1:ncep-1]π/lift))]
+        liftw = [1; (1 + lift/2*sin(collect(1:ncep-1)π/lift))]
     end
     if invs
         liftw = 1./liftw


### PR DESCRIPTION
This is to deal with warnings such as:

```
WARNING: [a] concatenation is deprecated; use collect(a) instead
 in depwarn at deprecated.jl:73
 in oldstyle_vcat_warning at ./abstractarray.jl:29
 in lifter at /home/james/.julia/v0.4/MFCC/src/rasta.jl:242
```

and

```
WARNING: [a,b] concatenation is deprecated; use [a;b] instead
 in depwarn at deprecated.jl:73
 in oldstyle_vcat_warning at ./abstractarray.jl:29
 in vect at abstractarray.jl:38
 in lifter at /home/james/.julia/v0.4/MFCC/src/rasta.jl:242
```