### PR TITLE
add FileIO explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ Compat
 HDF5
 JLD
 WAV
+FileIO


### PR DESCRIPTION
instead of assuming it will be present as a transitive dependency