### PR TITLE
vcat fix for julia 0.5

### DIFF
--- a/src/rasta.jl
+++ b/src/rasta.jl
@@ -240,7 +240,7 @@ function lifter{T<:AbstractFloat}(x::Array{T}, lift::Real=0.6, invs=false)
             error("Negative lift must be interger")
         end
         lift = -lift            # strictly speaking unnecessary...
-        liftw = [1, (1 + lift/2*sin(collect(1:ncep-1)π/lift))]
+        liftw = vcat(1, (1 + lift/2*sin(collect(1:ncep-1)π/lift)))
     end
     if invs
         liftw = 1./liftw


### PR DESCRIPTION
I just upgraded to Julia 0.5 and found this would cause an error. Without vcat, this would create a 2 element array with an integer and an inner array.