### PR TITLE
add no dct option

### DIFF
--- a/src/rasta.jl
+++ b/src/rasta.jl
@@ -199,6 +199,9 @@ function lpc2cep{T<:AbstractFloat}(a::Array{T}, ncep::Int=0)
 end
 
 function spec2cep{T<:AbstractFloat}(spec::Array{T}, ncep::Int=13, dcttype::Int=2)
+    # no discrete cosine transform option
+    dcttype == -1 && return log(spec)
+
     (nr, nc) = size(spec)
     dctm = zeros(typeof(spec[1]), ncep, nr)
     if 1 < dcttype < 4          # type 2,3


### PR DESCRIPTION
Maybe it is not practical -I don't know-, but I've just added "no discrete cosine transformation" option to the feature extractor. One paper I'm trying to implement takes advantage of that kind of features, so this is the reason why I need it.