### PR TITLE
Automerge fix for v0.3.5 [skip ci]

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,45 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@latest
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MFCC"
 uuid = "ca7b5df7-6146-5dcc-89ec-36256279a339"
 authors = ["David van Leeuwen"]
-version = "0.3.6"
+version = "0.3.5"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
@@ -18,12 +18,17 @@ WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [compat]
 DSP = "0.6, 0.7"
+Distributed = "1"
 FFTW = "1"
 FileIO = "1"
 HDF5 = "0.15 - 0.17"
-SpecialFunctions = "0.8, 1, 2"
+LinearAlgebra = "1"
+Memoization = "0.2"
+SpecialFunctions = "0.8 - 2"
+Statistics = "1"
+Test = "1"
 WAV = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/feacalc.jl
+++ b/src/feacalc.jl
@@ -10,7 +10,7 @@ ncol(x) = size(x, 2)
 compute features according to standard settings directly from a wav file.
 this does channel at the time.
 """
-function feacalc(wavfile::AbstractString; method=:wav, kwargs...)
+function feacalc(wavfile; method=:wav, kwargs...)
     x, sr = if method == :wav
         wavread(wavfile)
     elseif method == :sox
@@ -103,7 +103,7 @@ function feacalc(x::AbstractVecOrMat; augtype=:ddelta, normtype=:warp, sadtype=:
 end
 
 ## When called with a specific application in mind, call with two arguments
-function feacalc(wavfile::AbstractString, application::Symbol; kwargs...)
+function feacalc(wavfile, application::Symbol; kwargs...)
     if application in (:speaker, :nbspeaker)
         feacalc(wavfile; defaults=:nbspeaker, kwargs...)
     elseif application == :wbspeaker

--- a/src/feacalc.jl
+++ b/src/feacalc.jl
@@ -48,8 +48,10 @@ function feacalc(x::AbstractVecOrMat; augtype=:ddelta, normtype=:warp, sadtype=:
         nsamples, nchan = length(x), 1
     end
     ## save some metadata
-    meta = Dict(:nsamples => nsamples, :sr => sr, :source => source,
-                :nchan => nchan, :chan => chan)
+    meta = Dict{Symbol, Any}(
+        :nsamples => nsamples, :sr => sr, :source => source,
+        :nchan => nchan, :chan => chan
+        )
     preemph = 0.97
     preemph ^= 16000. / sr
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -11,9 +11,9 @@ import HDF5
 HDF5.write(fd::HDF5.File, s::AbstractString, sym::Symbol) = write(fd, string(s,":Symbol"), string(sym))
 
 ## always save data in Float32
-## the functiona arguments are the same as the output of feacalc
+## the function arguments are the same as the output of feacalc
 ## x: the MFCC data
-## meta: a dict with parameters anout the data, nsamples, nframes, totnframes (before sad), ...
+## meta: a dict with parameters about the data, nsamples, nframes, totnframes (before sad), ...
 ## params: a dict with parameters about the feature extraction itself.
 function feasave(file::AbstractString, x::AbstractMatrix{<:AbstractFloat}; meta::Dict=Dict(), params::Dict=Dict())
     dir = dirname(file)

--- a/src/mfccs.jl
+++ b/src/mfccs.jl
@@ -17,7 +17,7 @@ function mfcc(x::AbstractVector{T}, sr::Real=16000.0; wintime=0.025, steptime=0.
               fbtype=:htkmel, bwidth=1.0, modelorder=0, dcttype=3, dither::Real=false,
               sumpower::Bool=false, usecmp::Bool=false) where {T<:AbstractFloat}
     if !iszero(preemph)
-        x = filt(PolynomialRatio([1., -preemph], [1.]), x)
+        x = filt([1., -preemph], 1., x)
     end
     pspec = powspec(x, sr; wintime=wintime, steptime=steptime, dither=dither)
     aspec = audspec(pspec, sr; nfilts=nbands, fbtype=fbtype, minfreq=minfreq,
@@ -82,7 +82,7 @@ function deltas(x::AbstractMatrix{T}, w::Integer=9) where {T<:AbstractFloat}
     xend = x[end:end, :]
     xx = vcat(repeat(x1, hlen), x, repeat(xend, hlen)) ## take care of boundaries
     norm = 3 / (hlen * w * (hlen + 1))
-    delta_v = filt(PolynomialRatio(win, [1.]), xx)[begin+2hlen:end, :]
+    delta_v = filt(win, 1., xx)[begin+2hlen:end, :]
     @. delta_v *= norm
     return delta_v
 end

--- a/src/mfccs.jl
+++ b/src/mfccs.jl
@@ -77,7 +77,7 @@ function deltas(x::AbstractMatrix{T}, w::Integer=9) where {T<:AbstractFloat}
     end
     hlen = w ÷ 2
     w = 2hlen + 1                 # make w odd
-    win = collect(convert(T, hlen):-1:-hlen)
+    win = collect(T, hlen:-1:-hlen)
     x1 = x[begin:begin, :]
     xend = x[end:end, :]
     xx = vcat(repeat(x1, hlen), x, repeat(xend, hlen)) ## take care of boundaries

--- a/src/mfccs.jl
+++ b/src/mfccs.jl
@@ -40,11 +40,13 @@ function mfcc(x::AbstractVector{T}, sr::Real=16000.0; wintime=0.025, steptime=0.
         cepstra = spec2cep(aspec, numcep, dcttype)
     end
     cepstra = lifter(cepstra, lifterexp)
-    meta = Dict(:sr => sr, :wintime => wintime, :steptime => steptime, :numcep => numcep,
-                :lifterexp => lifterexp, :sumpower => sumpower, :preemph => preemph,
-                :dither => dither, :minfreq => minfreq, :maxfreq => maxfreq, :nbands => nbands,
-                :bwidth => bwidth, :dcttype => dcttype, :fbtype => fbtype,
-                :usecmp => usecmp, :modelorder => modelorder)
+    meta = Dict{Symbol, Any}(
+        :sr => sr, :wintime => wintime, :steptime => steptime, :numcep => numcep,
+        :lifterexp => lifterexp, :sumpower => sumpower, :preemph => preemph,
+        :dither => dither, :minfreq => minfreq, :maxfreq => maxfreq, :nbands => nbands,
+        :bwidth => bwidth, :dcttype => dcttype, :fbtype => fbtype,
+        :usecmp => usecmp, :modelorder => modelorder
+        )
     return (cepstra, pspec', meta)
 end
 

--- a/src/rasta.jl
+++ b/src/rasta.jl
@@ -50,7 +50,8 @@ function audspec(x::AbstractMatrix{<:AbstractFloat}, sr::Real=16000.0;
     if sumpower
         return wts_v * x
     else
-        return (wts_v * sqrt.(x)).^2
+        aspec = wts_v * sqrt.(x)
+        return map!(x->x^2, aspec, aspec)
     end
 end
 

--- a/src/rasta.jl
+++ b/src/rasta.jl
@@ -180,21 +180,22 @@ function postaud(x::AbstractMatrix{<:AbstractFloat}, fmax::Real, fbtype=:bark, b
     if broaden
         z = z[[begin; begin:end; end], :];
     else
-        z = z[[begin+1; begin+1:end-1; end-1], :]
+        @views z[[begin, end], :] = z[[begin+1, end-1], :]
     end
     return z
 end
 
 function dolpc(x::AbstractMatrix{<:AbstractFloat}, modelorder::Int=8)
     nbands, nframes = size(x)
-    r = real(ifft(x[[begin:end; end-1:-1:begin+1], :], 1)[begin:begin+nbands-1, :])
+    r = FFTW.r2r(x, FFTW.REDFT00, 1)
+    r ./= 2(nbands - 1)
     # Find LPC coeffs by durbin
     y, e = levinson(r, modelorder)
     # Normalize each poly by gain
     y ./= e
 end
 
-function lpc2cep(a::AbstractMatrix{T}, ncep::Int=0) where {T<:AbstractFloat}
+@views function lpc2cep(a::AbstractMatrix{T}, ncep::Int=0) where {T<:AbstractFloat}
     nlpc, nc = size(a)
     order = nlpc - 1
     if iszero(ncep)
@@ -202,15 +203,15 @@ function lpc2cep(a::AbstractMatrix{T}, ncep::Int=0) where {T<:AbstractFloat}
     end
     c = zeros(nc, ncep)
     a = copy(a')
+    sum_var = collect(T, a[:, begin])
     # Code copied from HSigP.c: LPC2Cepstrum
     # First cep is log(Error) from Durbin
-    @views @. c[:, begin] = -log(a[:, begin])
+    @. c[:, begin] = -log(sum_var)
     # Renormalize lpc A coeffs
-    @. a /= a[:, begin]
-    sum_var = Vector{T}(undef, nc)
-    @views for i in 2:ncep
+    @. a /= sum_var
+    for i in 2:ncep
         fill!(sum_var, zero(T))
-        for m in 2:i
+        for m in 2:i-1
             @. sum_var += (i - m) * a[:, m] * c[:, i - m + 1]
         end
         @. c[:, i] = -a[:, i] - sum_var / (i - 1)
@@ -285,35 +286,33 @@ end
 ## "You are welcome to move my octave code from GPL to MIT like core Julia."
 ## untested
 ## only returns a, v
-function levinson(acf::AbstractVector{<:Number}, p::Int)
+@views function levinson(acf::AbstractVector{<:Number}, p::Int)
     if isempty(acf)
         throw(ArgumentError("Empty autocorrelation function"))
-    end
-    if p < 0
+    elseif p < 0
         throw(DomainError(p, "Negative model order"))
-    end
-    if p < 100
+    elseif p < 100
         ## direct solution [O(p^3), but no loops so slightly faster for small p]
         ## Kay & Marple Eqn (2.39)
-        R = toeplitz(@view acf[begin:begin+p-1])
-        a = R \ @view acf[begin+1:begin+p]
+        R = toeplitz(acf[begin:begin+p-1])
+        a = R \ acf[begin+1:begin+p]
         @. a = -a
         pushfirst!(a, 1)
-        v = @. real(a*conj(@view acf[begin:begin+p]))
+        v = @. real(a*conj(acf[begin:begin+p]))
     else
         ## durbin-levinson [O(p^2), so significantly faster for large p]
         ## Kay & Marple Eqns (2.42-2.46)
         # ref = zeros(p)
         g = -acf[begin+1] / acf[begin]
-        a = [1, g]; sizehint!(a, p+1)
+        a = zeros(p+1); a[1] = 1; a[2] = g
+        buf = similar(a)
         v = real((1 - abs2(g)) * acf[begin])
         # ref[begin] = g  # is not used???
         for t in 2:p
-            g = -(acf[begin+t] + @views a[2:end] ⋅ acf[begin+t-1:-1:begin+1]) / v
-            for i in 2:t
-                a[i] = a[i] + g * conj(a[end-i+2])
-            end
-            push!(a, g)
+            g = -(acf[begin+t] + a[2:t] ⋅ acf[begin+t-1:-1:begin+1]) / v
+            @. buf[2:t] = g * conj(a[t:-1:2])
+            @. a[2:t] += buf[2:t]
+            a[t+1] = g
             v *= 1 - abs2(g)
             # ref[t] = g
         end
@@ -326,7 +325,9 @@ function levinson(acf::AbstractMatrix{<:Number}, p::Integer)
     a = zeros(p + 1, nc)
     v = zeros(p + 1, nc)
     for i in axes(acf, 2)
-        a[:, i], v[:, i] = levinson(view(acf, :, i), p)
+        a_i, v_i = levinson(view(acf, :, i), p)
+        a[:, i] = a_i
+        v[:, i] .= v_i
     end
     return a, v
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,74 +9,83 @@ using Test
 
 import MFCC: sad, levinson, toeplitz
 
-# test io
-
 x, meta, params = feacalc("bl2.wav", normtype=:none, method=:wav, augtype=:none, sadtype=:none)
-y = feaload("bl2.mfcc")
 
-@assert x == y
+# test io
+@testset "io" begin
+    y = @test_nowarn feaload("bl2.mfcc")
 
-t_fn = "mfccs/bl2.hdf5"
+    @test x == y
 
-feasave(t_fn, x; meta=meta, params=params)
-mfcc_tup = feaload(t_fn; meta=true, params=true)
+    t_fn = "../bl2.hdf5"
 
-@assert feasize(t_fn) == size(y)
-@assert mfcc_tup == (x, meta, params)
+    @test_nowarn feasave(t_fn, x; meta=meta, params=params)
+    mfcc_tup = @test_nowarn feaload(t_fn; meta=true, params=true)
 
-rm(t_fn)
+    @test feasize(t_fn) == size(y)
+    @test mfcc_tup == (x, meta, params)
+
+    rm(t_fn)
+end
 
 y, sr = wavread("bl2.wav"); y_mat = y
 y, sr = vec(y), Float64(sr)
 
 # test feacalc with different parameters
-feacalc(y; normtype=:mvn)
-feacalc(y_mat; sr=sr, chan=1)
-feacalc(y_mat; sr=sr, chan=:a, augtype=:sdc)
-feacalc(y; sr=sr, usecmp=true, modelorder=20, dcttype=1)
-
-# test mfcc with htk, matrix input
-mfcc(repeat(y, 1, 2), sr, :htk)
-
-for defaults in (:nbspeaker, :wbspeaker, :language, :diarization)
-    feacalc("bl2.wav", defaults)
+@testset "feacalc" begin
+    @test_nowarn feacalc(y; normtype=:mvn)
+    @test_nowarn feacalc(y_mat; sr=sr, chan=1)
+    @test_nowarn feacalc(y_mat; sr=sr, chan=:a, augtype=:sdc)
+    @test_nowarn feacalc(y; sr=sr, usecmp=true, modelorder=20, dcttype=1)
+    for defaults in (:nbspeaker, :wbspeaker, :language, :diarization)
+        @test_nowarn feacalc("bl2.wav", defaults)
+    end
 end
 
-for (fb, dcttype) in zip((:bark, :mel, :htkmel), (1, 3, 4))
-    mfcc(y; usecmp=true, fbtype=fb, dcttype=dcttype)
+@testset "mfcc" begin
+    # test mfcc with htk, matrix input
+    @test_nowarn mfcc(repeat(y, 1, 2), sr, :htk)
+
+    for (fb, dcttype) in zip((:bark, :mel, :htkmel), (1, 3, 4))
+        @test_nowarn mfcc(y; usecmp=true, fbtype=fb, dcttype=dcttype)
+    end
 end
 
-speech = sad("bl2.wav", devnull, devnull)
+@testset "rasta + utilities" begin
+    @test_nowarn sad("bl2.wav", devnull, devnull)
 
-z = warp(x)
-z = warp(x, 100)
-z = deltas(x)
-z = deltas(x, 1)
-z = znorm(x)
-z = stmvn(x)
+    @test_nowarn warp(x)
+    @test_nowarn warp(x, 100)
+    @test_nowarn deltas(x)
+    @test_nowarn deltas(x, 1)
+    @test_nowarn znorm(x)
+    @test_nowarn stmvn(x)
 
-x = randn(100000)
-l = levinson(x, 101)
-z = lifter(x, 0.6, true)
-z = stmvn(x, 400000)
-z = warp(randn(1000))
-p = powspec(x)
-a = audspec(p)
-a = postaud(p, 8000, :bark, true)
+    v = randn(100000)
+    @test_nowarn levinson(v, 101)
+    @test_nowarn lifter(v, 0.6, true)
+    @test_nowarn stmvn(v, 400000)
+    @test_nowarn warp(randn(1000))
+    p = @test_nowarn powspec(v)
+    a = @test_nowarn audspec(p)
+    a = @test_nowarn postaud(a, 8000, :bark, true)
+end
 
 # test for invalid/unsupported arguments
-@test_throws DomainError feacalc(y_mat; sr=sr, chan=2)
-@test_throws ArgumentError feacalc(y_mat; sr=sr, chan=nothing)
-@test_throws ArgumentError feacalc(y; sr=sr, usecmp=true, modelorder=1, dcttype=1)
-@test_throws ArgumentError feacalc(y; sr=sr, usecmp=true, modelorder=1, dcttype=2)
-@test_throws ArgumentError feacalc("bl2.wav", :bosespeaker)
-@test_throws ArgumentError mfcc(y, sr, :pasta)
-@test_throws ArgumentError postaud(a, 4000, :cough)
-@test_throws "Lift number is too high (>10)" lifter(y, 100)
-@test_throws "Negative lift must be integer" lifter(y, -0.6)
-@test_throws ArgumentError levinson(Int[], 1)
-@test_throws DomainError levinson(x, -1)
+@testset "Test throws for invalid arguments" begin
+    @test_throws DomainError feacalc(y_mat; sr=sr, chan=2)
+    @test_throws ArgumentError feacalc(y_mat; sr=sr, chan=nothing)
+    @test_throws ArgumentError feacalc(y; sr=sr, usecmp=true, modelorder=1, dcttype=1)
+    @test_throws ArgumentError feacalc(y; sr=sr, usecmp=true, modelorder=1, dcttype=2)
+    @test_throws ArgumentError feacalc("bl2.wav", :bosespeaker)
+    @test_throws ArgumentError mfcc(y, sr, :pasta)
+    @test_throws ArgumentError postaud(y_mat, 4000, :cough)
+    @test_throws "Lift number is too high (>10)" lifter(y, 100)
+    @test_throws "Negative lift must be integer" lifter(y, -0.6)
+    @test_throws ArgumentError levinson(Int[], 1)
+    @test_throws DomainError levinson(x, -1)
 
-@test_warn "First elements of a Toeplitz matrix should be equal." toeplitz([1+im])
+    @test_warn "First elements of a Toeplitz matrix should be equal." toeplitz([1 + im])
+end
 
 println("Tests passed")


### PR DESCRIPTION
Hopefully registering this will auto-merge? Also [this auto-merge](https://github.com/JuliaRegistries/General/pull/94959#issuecomment-1801296458) may need cancelling.
Not sure if it's fine to bump the required Julia version up to 1.6, but if not then [this](https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958) may help?

- version changed back to 0.3.5 so versions don't skip
- add v1 compat for stdlibs (Distributed, LinearAlgebra, Statistics, Test)
- add compat for Memoization
- bump required Julia version to LTS (1.6)